### PR TITLE
Replace strings with byte-strings so hub-list-backups works

### DIFF
--- a/hublib/keypacket.py
+++ b/hublib/keypacket.py
@@ -41,12 +41,12 @@ def _repeat(f, input, count):
     return input
 
 def _cipher_key(passphrase, repeats):
-    cipher_key = _repeat(lambda k: hashlib.sha256(k).digest(),
+    cipher_key = _repeat(lambda k: hashlib.sha256(k.encode()).digest(),
                          passphrase, repeats)
     return cipher_key
 
 def _cipher(cipher_key):
-    return AES.new(cipher_key, mode=AES.MODE_CBC, IV='\0' * 16)
+    return AES.new(cipher_key, mode=AES.MODE_CBC, IV=b'\0' * 16)
 
 def fmt(secret, passphrase):
     salt = os.urandom(SALT_LEN)


### PR DESCRIPTION
As per subject - fixes for `hub-list-backups`.

Closes https://github.com/turnkeylinux/tracker/issues/1917