### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #! /usr/bin/make -f
 
-export DH_VERBOSE = 1
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make hubtools reproducible.

FYI setting `DH_VERBOSE` is useful for debugging packaging issues, but not required.
